### PR TITLE
adding onlyNumber as an input

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Once it is imported, you can use `international-phone-number`:
        defaultCountryCode : An ISO 639-1 country code can be provided to set default country selected.
        placeholder: A placeholder text which would be displayed in input widget
        required: Indicates whether it's required or not
+       onlyNumber: Indicates whether the user can type only numbers or not in the input field. It defaults to true.
        allowDropdown: Indicates whether to allow selecting country from dropdown
        allowedCountries: A list of countries (iso codes) that would get display in country dropdown. E.g. [allowedCountries]="['in', 'ca', 'us']" would only show Canada, India and US. If not provided, all the countries would get displayed.
 

--- a/src/phone-number.component.html
+++ b/src/phone-number.component.html
@@ -19,10 +19,10 @@
   </span>
 
   <!-- if required -->
-  <input onlyNumber="true" class="form-control" [attr.maxlength]="maxlength" [(ngModel)]="phoneNumber" (ngModelChange)="updatePhoneNumber($event)" 
+  <input [onlyNumber]="onlyNumber" class="form-control" [attr.maxlength]="maxlength" [(ngModel)]="phoneNumber" (ngModelChange)="updatePhoneNumber($event)" 
   [placeholder]="placeholder" [type]="type" *ngIf="required" required #phoneNumberInput>
   
   <!-- if not required -->
-  <input onlyNumber="true" class="form-control" [attr.maxlength]="maxlength" [(ngModel)]="phoneNumber" (ngModelChange)="updatePhoneNumber($event)" 
+  <input [onlyNumber]="onlyNumber" class="form-control" [attr.maxlength]="maxlength" [(ngModel)]="phoneNumber" (ngModelChange)="updatePhoneNumber($event)" 
   [placeholder]="placeholder" [type]="type" *ngIf="!required" #phoneNumberInput>
 </div>

--- a/src/phone-number.component.ts
+++ b/src/phone-number.component.ts
@@ -54,7 +54,7 @@ export class PhoneNumberComponent
     @Input() required: boolean;
     @Input() allowDropdown = true;
     @Input() type = 'text';
-
+    @Input() onlyNumber = true;
     @Input() allowedCountries: Country[];
 
     @Output() onCountryCodeChanged: EventEmitter<any> = new EventEmitter();


### PR DESCRIPTION
I was in a situation where I should let the user type non numeric characters in the input available by this library.

I checked the library this one is based on and saw that there is actually  an input that was always set to true in the ngx-international-phone implementation.

My suggestion is that this should be an Input available to the user that should default to true.